### PR TITLE
all get_hosts parameters are optional; should be hash

### DIFF
--- a/lib/mackerel/client.rb
+++ b/lib/mackerel/client.rb
@@ -29,14 +29,14 @@ module Mackerel
       data = JSON.parse(response.body)
     end
 
-    def get_hosts(service = nil, roles = nil, opts = {})
+    def get_hosts(opts = {})
       client = http_client
 
       response = client.get '/api/v0/hosts.json' do |req|
         req.headers['X-Api-Key'] = @api_key
-        req.params['service']    = service     if service
-        req.params['role']       = roles       if roles
-        req.params['name']       = opts[:name] if opts[:name]
+        req.params['service']    = opts[:service] if opts[:service]
+        req.params['role']       = opts[:roles]   if opts[:roles]
+        req.params['name']       = opts[:name]    if opts[:name]
       end
 
       unless response.success?


### PR DESCRIPTION
now get_hosts supports 'name' option neithor 'service' nor 'name'
relaxed hash parameter is easier to use

this breaks compatibility of `get_hosts`
