### PR TITLE
Fix error message when api_key is absent

### DIFF
--- a/lib/mackerel/client.rb
+++ b/lib/mackerel/client.rb
@@ -8,9 +8,11 @@ module Mackerel
 
   class Client
 
+    ERROR_MESSAGE_FOR_API_KEY_ABSENCE = "API key is absent. Set your API key in a environment variable called MACKEREL_APIKEY."
+
     def initialize(args = {})
       @origin  = args[:mackerel_origin] || 'https://mackerel.io'
-      @api_key = args[:mackerel_api_key]
+      @api_key = args[:mackerel_api_key] || raise(ERROR_MESSAGE_FOR_API_KEY_ABSENCE)
     end
 
     def get_host(host_id)

--- a/spec/mackerel/client_spec.rb
+++ b/spec/mackerel/client_spec.rb
@@ -6,6 +6,13 @@ describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 
+  describe 'initialization' do
+    it 'display an error message when api_key is absent' do
+      expected_message = "API key is absent. Set your API key in a environment variable called MACKEREL_APIKEY."
+      expect { Mackerel::Client.new() }.to raise_error(expected_message)
+    end
+  end
+
   describe '#get_host' do
     let(:stubbed_response) {
       [


### PR DESCRIPTION
I just tried mkr for the first time, and the CLI displayed the following error. Yes, the reason was that the `MACKEREL_APIKEY` environment variable was absent on the machine.

```
$ mkr host status --host-id foo --status working
Error: undefined method `strip' for nil:NilClass
```

This PR improves the error message to suggest users what they should do next. If you don't prefer the error message, please let me know better one.
