### PR TITLE
Make get_hosts accepts status option

### DIFF
--- a/lib/mackerel/client.rb
+++ b/lib/mackerel/client.rb
@@ -110,6 +110,7 @@ module Mackerel
         req.params['service']    = opts[:service] if opts[:service]
         req.params['role']       = opts[:roles]   if opts[:roles]
         req.params['name']       = opts[:name]    if opts[:name]
+        req.params['status']     = opts[:status]  if opts[:status]
       end
 
       unless response.success?


### PR DESCRIPTION
`/api/v0/hosts.json` accepts `status` parameters, but mackerel-client-ruby's `get_hosts` doesn't accept them.
So I added a new key `status` to `req.params`.