### PR TITLE
Added helper file for auto require specification of bundler

### DIFF
--- a/lib/mackerel-client.rb
+++ b/lib/mackerel-client.rb
@@ -1,0 +1,1 @@
+require 'mackerel'


### PR DESCRIPTION
bundler invoke `require GEMNAME` with `Bundler.setup`. I added simple helper file for bundler specification. many of gems  adopted this workaround like this:

 * https://github.com/kpumuk/meta-tags/blob/master/lib/meta-tags.rb
 * https://github.com/r7kamura/rspec-json_matcher/blob/master/lib/rspec-json_matcher.rb
 * etc...etc...

How do you think about this helper file? I think this helper is useful under the bundler environment.