### PR TITLE
Add #define_graphs method to Mackerel::Client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+before_install: gem install bundler -v 1.11.2
 rvm:
   - "2.1.1"
   - "2.0.0"

--- a/lib/mackerel/client.rb
+++ b/lib/mackerel/client.rb
@@ -104,6 +104,20 @@ module Mackerel
       data = JSON.parse(response.body)
     end
 
+    def define_graphs(graph_defs)
+      response = client.post '/api/v0/graph-defs/create' do |req|
+        req.headers['X-Api-Key'] = @api_key
+        req.headers['Content-Type'] = 'application/json'
+        req.body = graph_defs.to_json
+      end
+
+      unless response.success?
+        raise "POST /api/v0/graph-defs/create failed: #{res.status} #{res.body}"
+      end
+
+      JSON.parse(response.body)
+    end
+
     def get_hosts(opts = {})
       response = client.get '/api/v0/hosts.json' do |req|
         req.headers['X-Api-Key'] = @api_key

--- a/spec/mackerel/client_spec.rb
+++ b/spec/mackerel/client_spec.rb
@@ -256,6 +256,63 @@ describe Mackerel::Client do
     end
   end
 
+  describe '#define_graphs' do
+    let(:stubbed_response) {
+      [
+        200,
+        {},
+        JSON.dump(response_object)
+      ]
+    }
+
+    let(:test_client) {
+      Faraday.new do |builder|
+        builder.adapter :test do |stubs|
+          stubs.post(api_path) { stubbed_response }
+        end
+      end
+    }
+
+    let(:api_path) { '/api/v0/graph-defs/create' }
+
+    let(:response_object) {
+      { 'success' => true }
+    }
+
+    let(:defs) { [
+      {
+        name: 'custom.fish-catch',
+        displayName: 'My fish catch',
+        unit: 'integer',
+        metrics: [
+          {
+            name: 'custom.fish-catch.mackerel',
+            displayName: 'Mackerel',
+            isStacked: false,
+          },
+          {
+            name: 'custom.fish-catch.herring',
+            displayName: 'Herring',
+            isStacked: false,
+          },
+          {
+            name: 'custom.fish-catch.salmon',
+            displayName: 'Salmon',
+            isStacked: false,
+          },
+        ]
+      }
+    ] }
+
+    before do
+      allow(client).to receive(:http_client).and_return(test_client)
+    end
+
+    it "successfully post metrics" do
+      expect(client.define_graphs(defs)).to eq(response_object)
+    end
+  end
+
   describe '#get_hosts' do
     let(:stubbed_response) {
       [


### PR DESCRIPTION
Mackerel provides an API to create a graph definition, but Mackerel::Client does not supported yet.

(Also updated Bundler to fix build)