### PR TITLE
Add Mackerel::Client::Helper.as_safe_metric_name

### DIFF
--- a/lib/mackerel/client/helper.rb
+++ b/lib/mackerel/client/helper.rb
@@ -1,0 +1,9 @@
+module Mackerel
+  class Client
+    module Helper
+      def self.as_safe_metric_name(str, replacement = '-')
+        str.gsub(/[^a-zA-Z0-9_\-]/, replacement)
+      end
+    end
+  end
+end

--- a/spec/mackerel/client/helper_spec.rb
+++ b/spec/mackerel/client/helper_spec.rb
@@ -1,0 +1,10 @@
+require 'mackerel/client/helper'
+
+describe Mackerel::Client::Helper do
+  describe '.as_safe_metric_name' do
+    it 'translates characters that cannot be used as a metric name to safe characters' do
+      name = 'readme.md'
+      expect(Mackerel::Client::Helper.as_safe_metric_name(name)).to eq('readme-md')
+    end
+  end
+end


### PR DESCRIPTION
Mackerel's metric name has some constraint:

http://help.mackerel.io/entry/spec/api/v0#graphdef-post

> which may contain [-a-zA-Z0-9_]+ , and wildcard characters * , or #

http://help-ja.mackerel.io/entry/spec/api/v0#graphdef-post

> [-a-zA-Z0-9_]+またはワイルドカード*, #

If we create a definition of graphs, we may write some code like:

https://github.com/aereal/psi-metrics/blob/master/Rakefile#L36-L38