### PR TITLE
Support POST /api/v0/hosts

### DIFF
--- a/lib/mackerel/client.rb
+++ b/lib/mackerel/client.rb
@@ -15,6 +15,20 @@ module Mackerel
       @api_key = args[:mackerel_api_key] || raise(ERROR_MESSAGE_FOR_API_KEY_ABSENCE)
     end
 
+    def post_host(host)
+      response = client.post "/api/v0/hosts" do |req|
+        req.headers['X-Api-Key'] = @api_key
+        req.headers['Content-Type'] = 'application/json'
+        req.body = host.to_json
+      end
+
+      unless response.success?
+        raise "POST /api/v0/hosts failed: #{response.status}"
+      end
+
+      data = JSON.parse(response.body)
+    end
+
     def get_host(host_id)
       response = client.get "/api/v0/hosts/#{host_id}" do |req|
         req.headers['X-Api-Key'] = @api_key

--- a/spec/mackerel/client_spec.rb
+++ b/spec/mackerel/client_spec.rb
@@ -13,6 +13,47 @@ describe Mackerel::Client do
     end
   end
 
+  describe '#post_host' do
+    let(:stubbed_response) {
+      [
+        200,
+        {},
+        JSON.dump(response_object)
+      ]
+    }
+
+    let(:test_client) {
+      Faraday.new do |builder|
+        builder.adapter :test do |stubs|
+          stubs.post(api_path) { stubbed_response }
+        end
+      end
+    }
+
+    let(:hostId) { '21obeF4PhZN' }
+
+    let(:api_path) { '/api/v0/hosts' }
+
+    let(:host) {
+      {
+        'name' => 'host001',
+        'meta' => {},
+      }
+    }
+
+    let(:response_object) {
+      { 'id' => hostId }
+    }
+
+    before do
+      allow(client).to receive(:http_client).and_return(test_client)
+    end
+
+    it "successfully post host" do
+      expect(client.post_host(host)).to eq(response_object)
+    end
+  end
+
   describe '#get_host' do
     let(:stubbed_response) {
       [


### PR DESCRIPTION
I'd like to add devices on which we cannot install mackerel-agent.
For example, [nasne](http://www.jp.playstation.com/nasne/), [Netatmo Weather Station](https://www.netatmo.com/ja-JP/product/weather-station) and so on.

So I've added the feature to support `POST /api/v1/hosts`.

Please check it.

Thanks in advance.
