### PR TITLE
Typo for `response`

### DIFF
--- a/lib/mackerel/client.rb
+++ b/lib/mackerel/client.rb
@@ -128,7 +128,7 @@ module Mackerel
       end
 
       unless response.success?
-        raise "POST /api/v0/graph-defs/create failed: #{res.status} #{res.body}"
+        raise "POST /api/v0/graph-defs/create failed: #{response.status} #{response.body}"
       end
 
       JSON.parse(response.body)


### PR DESCRIPTION
Hi,
I found a typo when I called `define_graphs` method. 
If you check and it is all right, could you merge?
Thank you.