### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,26 @@ mackerel-client is a ruby library to access Mackerel (https://mackerel.io/). CLI
 host = @mackerel.get_host("<hostId>")
 ```
 
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'mackerel-client'
+```
+
+And then execute:
+
+```sh
+bundle
+```
+
+Or install it yourself as:
+
+```sh
+gem install mackerel-client
+```
+
 # CLI
 
 ## Host


### PR DESCRIPTION
Currently the README has no installation instruction.

Installation of mackerel-client-ruby is a little confusing due to inconsistency between repository name and gem name.

Format of the instruction is conformed to `bundle gem`'s auto-generated document.