### PR TITLE
Support posting graph annotations

### DIFF
--- a/lib/mackerel/client.rb
+++ b/lib/mackerel/client.rb
@@ -151,6 +151,20 @@ module Mackerel
       data['hosts'].map{ |host_json| Host.new(host_json) }
     end
 
+    def post_graph_annotation(annotation)
+      response = client.post '/api/v0/graph-annotations' do |req|
+        req.headers['X-Api-Key'] = @api_key
+        req.headers['Content-Type'] = 'application/json'
+        req.body = annotation.to_json
+      end
+
+      unless response.success?
+        raise "POST /api/v0/graph-annotations failed: #{response.status} #{response.body}"
+      end
+
+      JSON.parse(response.body)
+    end
+
     private
 
     def client

--- a/spec/mackerel/client_spec.rb
+++ b/spec/mackerel/client_spec.rb
@@ -435,7 +435,15 @@ describe Mackerel::Client do
     let(:api_path) { '/api/v0/graph-annotations' }
 
     let(:response_object) {
-      { 'success' => true }
+      {
+        'id' => 'XXX',
+        'service' => 'myService',
+        'role' => ['role1', 'role2'],
+        'from' => 123456,
+        'to' => 123457,
+        'title' => 'Some event',
+        'description' => 'Something happend!'
+      }
     }
 
     let(:annotation) {

--- a/spec/mackerel/client_spec.rb
+++ b/spec/mackerel/client_spec.rb
@@ -414,4 +414,47 @@ describe Mackerel::Client do
       expect(client.get_hosts(opts).map(&:to_h)).to eq(hosts.map(&:to_h))
     end
   end
+
+  describe '#post_graph_annotation' do
+    let(:stubbed_response) {
+      [
+        200,
+        {},
+        JSON.dump(response_object)
+      ]
+    }
+
+    let(:test_client) {
+      Faraday.new do |builder|
+        builder.adapter :test do |stubs|
+          stubs.post(api_path) { stubbed_response }
+        end
+      end
+    }
+
+    let(:api_path) { '/api/v0/graph-annotations' }
+
+    let(:response_object) {
+      { 'success' => true }
+    }
+
+    let(:annotation) {
+      {
+        service: 'myService',
+        role: ['role1', 'role2'],
+        from: 123456,
+        to: 123457,
+        title: 'Some event',
+        description: 'Something happend!'
+      }
+    }
+
+    before do
+      allow(client).to receive(:http_client).and_return(test_client)
+    end
+
+    it "successfully post annotations" do
+      expect(client.post_graph_annotation(annotation)).to eq(response_object)
+    end
+  end
 end


### PR DESCRIPTION
ref(ja): https://mackerel.io/ja/api-docs/entry/graph-annotations

Implemented only `POST /api/v0/graph-annotations`, to create graph annotations in Capistrano deploy hook.