### PR TITLE
[nit] Fix a request parameter in test.

### DIFF
--- a/spec/mackerel/client_spec.rb
+++ b/spec/mackerel/client_spec.rb
@@ -438,7 +438,7 @@ describe Mackerel::Client do
       {
         'id' => 'XXX',
         'service' => 'myService',
-        'role' => ['role1', 'role2'],
+        'roles' => ['role1', 'role2'],
         'from' => 123456,
         'to' => 123457,
         'title' => 'Some event',
@@ -449,7 +449,7 @@ describe Mackerel::Client do
     let(:annotation) {
       {
         service: 'myService',
-        role: ['role1', 'role2'],
+        roles: ['role1', 'role2'],
         from: 123456,
         to: 123457,
         title: 'Some event',


### PR DESCRIPTION
A request parameter in test spec added in #28 is wrong, so fix it.
(Though this change itself doesn't affect mackerel-client-ruby's behavior, but wrong parameters may confuse users.)