### PR TITLE
Add support for metadata APIs

### DIFF
--- a/lib/mackerel/client.rb
+++ b/lib/mackerel/client.rb
@@ -166,6 +166,57 @@ module Mackerel
       JSON.parse(response.body)
     end
 
+    def list_metadata(host_id)
+      response = client.get "/api/v0/hosts/#{host_id}/metadata" do |req|
+        req.headers['X-Api-Key'] = @api_key
+      end
+
+      unless response.success?
+        raise "GET /api/v0/hosts/#{host_id}/metadata failed: #{response.status} #{response.body}"
+      end
+
+      JSON.parse(response.body)
+    end
+
+    def get_metadata(host_id, namespace)
+      response = client.get "/api/v0/hosts/#{host_id}/metadata/#{namespace}" do |req|
+        req.headers['X-Api-Key'] = @api_key
+      end
+
+      unless response.success?
+        raise "GET /api/v0/hosts/#{host_id}/metadata/#{namespace} failed: #{response.status} #{response.body}"
+      end
+
+      JSON.parse(response.body)
+    end
+
+    def update_metadata(host_id, namespace, data)
+      response = client.put "/api/v0/hosts/#{host_id}/metadata/#{namespace}" do |req|
+        req.headers['X-Api-Key'] = @api_key
+        req.headers['Content-Type'] = 'application/json'
+        req.body = data.to_json
+      end
+
+      unless response.success?
+        raise "POST /api/v0/hosts/#{host_id}/metadata/#{namespace} failed: #{response.status} #{response.body}"
+      end
+
+      JSON.parse(response.body)
+    end
+
+    def delete_metadata(host_id, namespace)
+      response = client.delete "/api/v0/hosts/#{host_id}/metadata/#{namespace}" do |req|
+        req.headers['X-Api-Key'] = @api_key
+        req.headers['Content-Type'] = 'application/json'
+      end
+
+      unless response.success?
+        raise "DELETE /api/v0/hosts/#{host_id}/metadata/#{namespace} failed: #{response.status} #{response.body}"
+      end
+
+      JSON.parse(response.body)
+    end
+
     private
 
     def client

--- a/spec/mackerel/client_spec.rb
+++ b/spec/mackerel/client_spec.rb
@@ -465,4 +465,141 @@ describe Mackerel::Client do
       expect(client.post_graph_annotation(annotation)).to eq(response_object)
     end
   end
+
+  describe '#list_metadata' do
+    let(:stubbed_response) { [200, {}, JSON.dump(response_object)] }
+
+    let(:test_client) {
+      Faraday.new do |builder|
+        builder.adapter :test do |stubs|
+          stubs.get(api_path) { stubbed_response }
+        end
+      end
+    }
+
+    let(:host_id) { '21obeF4PhZN' }
+
+    let(:api_path) { "/api/v0/hosts/#{host_id}/metadata" }
+
+    let(:response_object) {
+      {
+        'metadata' => [
+          { 'namespace' => 'namespace1' },
+          { 'namespace' => 'namespace2' }
+        ]
+      }
+    }
+
+    before do
+      allow(client).to receive(:http_client).and_return(test_client)
+    end
+
+    it 'successfully gets metadata namespaces' do
+      expect(client.list_metadata(host_id)).to eq(response_object)
+    end
+  end
+
+  describe '#get_metadata' do
+    let(:stubbed_response) { [200, {}, JSON.dump(response_object)] }
+
+    let(:test_client) {
+      Faraday.new do |builder|
+        builder.adapter :test do |stubs|
+          stubs.get(api_path) { stubbed_response }
+        end
+      end
+    }
+
+    let(:host_id) { '21obeF4PhZN' }
+
+    let(:namespace) { 'namespace' }
+
+    let(:api_path) { "/api/v0/hosts/#{host_id}/metadata/#{namespace}" }
+
+    let(:response_object) {
+      {
+        'type' => 12345,
+        'region' => 'jp',
+        'env' => 'staging',
+        'instance_type' => 'c4.xlarge'
+      }
+    }
+
+    before do
+      allow(client).to receive(:http_client).and_return(test_client)
+    end
+
+    it 'successfully gets metadata' do
+      expect(client.get_metadata(host_id, namespace)).to eq(response_object)
+    end
+  end
+
+  describe '#update_metadata' do
+    let(:stubbed_response) { [200, {}, JSON.dump(response_object)] }
+
+    let(:test_client) {
+      Faraday.new do |builder|
+        builder.adapter :test do |stubs|
+          stubs.put(api_path) { stubbed_response }
+        end
+      end
+    }
+
+    let(:host_id) { '21obeF4PhZN' }
+
+    let(:namespace) { 'namespace' }
+
+    let(:api_path) { "/api/v0/hosts/#{host_id}/metadata/#{namespace}" }
+
+    let(:response_object) {
+      { 'success' => true }
+    }
+
+    let(:metadata) {
+      {
+        'type' => 12345,
+        'region' => 'jp',
+        'env' => 'staging',
+        'instance_type' => 'c4.xlarge'
+      }
+    }
+
+    before do
+      allow(client).to receive(:http_client).and_return(test_client)
+    end
+
+    it 'successfully updates metadata' do
+      expect(client.update_metadata(host_id, namespace, metadata)).to eq(response_object)
+    end
+  end
+
+  describe '#delete_metadata' do
+    let(:stubbed_response) { [200, {}, JSON.dump(response_object)] }
+
+    let(:test_client) {
+      Faraday.new do |builder|
+        builder.adapter :test do |stubs|
+          stubs.delete(api_path) { stubbed_response }
+        end
+      end
+    }
+
+    let(:host_id) { '21obeF4PhZN' }
+
+    let(:namespace) { 'namespace' }
+
+    let(:api_path) { "/api/v0/hosts/#{host_id}/metadata/#{namespace}" }
+
+    let(:response_object) {
+      { 'success' => true }
+    }
+
+    before do
+      allow(client).to receive(:http_client).and_return(test_client)
+    end
+
+    it 'successfully updates metadata' do
+      expect(client.delete_metadata(host_id, namespace)).to eq(response_object)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds following methods to `Mackerel::Client`.

- `list_metadata(host_id)`
- `get_metadata(host_id, namespace)`
- `update_metadata(host_id, namespace)`
- `delete_metadata(host_id, namespace)`

I think we need to refactor test code... 😃 