### PR TITLE
Make Mackerel::Client works with `require 'mackerel/client'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ mackerel-client is a ruby library to access Mackerel (https://mackerel.io/). CLI
 ## Usage
 
 ```ruby
+require 'mackerel/client'
+
 @mackerel = Mackerel::Client.new(:mackerel_api_key => "<Put your API key>")
 host = @mackerel.get_host("<hostId>")
 ```

--- a/lib/mackerel.rb
+++ b/lib/mackerel.rb
@@ -1,4 +1,3 @@
 require 'mackerel/client'
-require 'mackerel/api_command'
 require 'mackerel/runner'
 require 'mackerel/version'

--- a/lib/mackerel/client.rb
+++ b/lib/mackerel/client.rb
@@ -3,6 +3,8 @@ require 'uri'
 
 require 'json' unless defined? ::JSON
 
+require 'mackerel/api_command'
+
 require 'mackerel/role'
 require 'mackerel/host'
 require 'mackerel/monitor'

--- a/lib/mackerel/version.rb
+++ b/lib/mackerel/version.rb
@@ -1,3 +1,3 @@
 module Mackerel
-  VERSION = "0.2.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
`require 'mackerel/client'` has been enough declaration to use `Mackerel::Client` in client < 0.4.0, but it does not work with 0.4.0. (ref: https://github.com/mackerelio/fluent-plugin-mackerel/pull/28)

Though it's not documented in this repository, requiring only 'mackerel/client' is described in many pages, even in our help: https://mackerel.io/docs/entry/advanced/capistrano-2.x

So, I'd like to restore the behavior.