### PR TITLE
explicitly specify TLS version 1.2 for HTTP client

### DIFF
--- a/lib/mackerel/client.rb
+++ b/lib/mackerel/client.rb
@@ -53,7 +53,7 @@ module Mackerel
     end
 
     def http_client
-      Faraday.new(:url => @origin) do |faraday|
+      Faraday.new(:url => @origin, :ssl => {:version => :TLSv1_2}) do |faraday|
         faraday.response :logger if ENV['DEBUG']
         faraday.adapter Faraday.default_adapter
         faraday.options.params_encoder = Faraday::FlatParamsEncoder


### PR DESCRIPTION
We Mackerel.io development team are planning to discontinue TLS 1.0 support then, I explicitly specify TLS version 1.2 for HTTP client.