### PR TITLE
Use Rspec v3.x

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/mackerel-client.gemspec
+++ b/mackerel-client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 0.9'
 
-  spec.add_development_dependency "rake", '~> 0'
-  spec.add_development_dependency "bundler", "~> 1.5"
-  spec.add_development_dependency "rspec", '~> 2'
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rspec"
 end

--- a/spec/mackerel/alert_spec.rb
+++ b/spec/mackerel/alert_spec.rb
@@ -1,4 +1,4 @@
-describe Mackerel::Client do
+RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 

--- a/spec/mackerel/alert_spec.rb
+++ b/spec/mackerel/alert_spec.rb
@@ -1,7 +1,3 @@
-require 'mackerel'
-require 'mackerel/host'
-require 'json'
-
 describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }

--- a/spec/mackerel/annotation_spec.rb
+++ b/spec/mackerel/annotation_spec.rb
@@ -1,4 +1,4 @@
-describe Mackerel::Client do
+RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 

--- a/spec/mackerel/annotation_spec.rb
+++ b/spec/mackerel/annotation_spec.rb
@@ -1,7 +1,3 @@
-require 'mackerel'
-require 'mackerel/host'
-require 'json'
-
 describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }

--- a/spec/mackerel/channel_spec.rb
+++ b/spec/mackerel/channel_spec.rb
@@ -1,4 +1,4 @@
-describe Mackerel::Client do
+RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 

--- a/spec/mackerel/channel_spec.rb
+++ b/spec/mackerel/channel_spec.rb
@@ -1,7 +1,3 @@
-require 'mackerel'
-require 'mackerel/host'
-require 'json'
-
 describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }

--- a/spec/mackerel/client/helper_spec.rb
+++ b/spec/mackerel/client/helper_spec.rb
@@ -1,6 +1,6 @@
 require 'mackerel/client/helper'
 
-describe Mackerel::Client::Helper do
+RSpec.describe Mackerel::Client::Helper do
   describe '.as_safe_metric_name' do
     it 'translates characters that cannot be used as a metric name to safe characters' do
       name = 'readme.md'

--- a/spec/mackerel/client_spec.rb
+++ b/spec/mackerel/client_spec.rb
@@ -1,4 +1,4 @@
-describe Mackerel::Client do
+RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 

--- a/spec/mackerel/client_spec.rb
+++ b/spec/mackerel/client_spec.rb
@@ -1,7 +1,3 @@
-require 'mackerel'
-require 'mackerel/host'
-require 'json'
-
 describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }

--- a/spec/mackerel/dashboard_spec.rb
+++ b/spec/mackerel/dashboard_spec.rb
@@ -1,4 +1,4 @@
-describe Mackerel::Client do
+RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 

--- a/spec/mackerel/dashboard_spec.rb
+++ b/spec/mackerel/dashboard_spec.rb
@@ -1,7 +1,3 @@
-require 'mackerel'
-require 'mackerel/host'
-require 'json'
-
 describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }

--- a/spec/mackerel/invitation_spec.rb
+++ b/spec/mackerel/invitation_spec.rb
@@ -1,4 +1,4 @@
-describe Mackerel::Client do
+RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 

--- a/spec/mackerel/invitation_spec.rb
+++ b/spec/mackerel/invitation_spec.rb
@@ -1,7 +1,3 @@
-require 'mackerel'
-require 'mackerel/host'
-require 'json'
-
 describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }

--- a/spec/mackerel/metric_spec.rb
+++ b/spec/mackerel/metric_spec.rb
@@ -1,4 +1,4 @@
-describe Mackerel::Client do
+RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 

--- a/spec/mackerel/metric_spec.rb
+++ b/spec/mackerel/metric_spec.rb
@@ -1,7 +1,3 @@
-require 'mackerel'
-require 'mackerel/host'
-require 'json'
-
 describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }

--- a/spec/mackerel/monitor_spec.rb
+++ b/spec/mackerel/monitor_spec.rb
@@ -1,4 +1,4 @@
-describe Mackerel::Client do
+RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 

--- a/spec/mackerel/monitor_spec.rb
+++ b/spec/mackerel/monitor_spec.rb
@@ -1,7 +1,3 @@
-require 'mackerel'
-require 'mackerel/host'
-require 'json'
-
 describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }

--- a/spec/mackerel/monitoring_spec.rb
+++ b/spec/mackerel/monitoring_spec.rb
@@ -1,4 +1,4 @@
-describe Mackerel::Client do
+RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 

--- a/spec/mackerel/monitoring_spec.rb
+++ b/spec/mackerel/monitoring_spec.rb
@@ -1,7 +1,3 @@
-require 'mackerel'
-require 'mackerel/host'
-require 'json'
-
 describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }

--- a/spec/mackerel/notification_group_spec.rb
+++ b/spec/mackerel/notification_group_spec.rb
@@ -1,4 +1,4 @@
-describe Mackerel::Client do
+RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 

--- a/spec/mackerel/notification_group_spec.rb
+++ b/spec/mackerel/notification_group_spec.rb
@@ -1,7 +1,3 @@
-require 'mackerel'
-require 'mackerel/host'
-require 'json'
-
 describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }

--- a/spec/mackerel/organization_spec.rb
+++ b/spec/mackerel/organization_spec.rb
@@ -1,4 +1,4 @@
-describe Mackerel::Client do
+RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 

--- a/spec/mackerel/organization_spec.rb
+++ b/spec/mackerel/organization_spec.rb
@@ -1,7 +1,3 @@
-require 'mackerel'
-require 'mackerel/host'
-require 'json'
-
 describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }

--- a/spec/mackerel/service_spec.rb
+++ b/spec/mackerel/service_spec.rb
@@ -1,4 +1,4 @@
-describe Mackerel::Client do
+RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 

--- a/spec/mackerel/service_spec.rb
+++ b/spec/mackerel/service_spec.rb
@@ -1,7 +1,3 @@
-require 'mackerel'
-require 'mackerel/host'
-require 'json'
-
 describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }

--- a/spec/mackerel/user_spec.rb
+++ b/spec/mackerel/user_spec.rb
@@ -1,4 +1,4 @@
-describe Mackerel::Client do
+RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 

--- a/spec/mackerel/user_spec.rb
+++ b/spec/mackerel/user_spec.rb
@@ -1,7 +1,3 @@
-require 'mackerel'
-require 'mackerel/host'
-require 'json'
-
 describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'mackerel'
+
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,4 +3,7 @@ require 'mackerel'
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
+
+  config.order = :random
+  Kernel.srand config.seed
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'mackerel'
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
+  config.filter_run_when_matching :focus
 
   config.order = :random
   Kernel.srand config.seed


### PR DESCRIPTION
* Relax development gem requirements
  * RSpec can upgrade to v3.x if there are no warnings on v2.99
* Configure spec_helper, .rspec
  * Add configurations that are well configured
