### PR TITLE
Add ruby version 2.3, 2.4, 2.5 to run test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ before_install:
   # https://github.com/travis-ci/travis-ci/issues/3531
   - gem install bundler # -v 1.7.14 if a specific version is needed
 rvm:
+  - "2.5"
+  - "2.4"
+  - "2.3"
   - "2.2"
   - "2.1.1"
   - "2.0.0"


### PR DESCRIPTION
We have tested it only with ruby 2.2 or less, but current stable ruby version is 2.5.

So I added version 2.3, 2.4, 2.5 to test it on travis.ci