### PR TITLE
fix unintended initializing http headers

### DIFF
--- a/lib/mackerel/api_command.rb
+++ b/lib/mackerel/api_command.rb
@@ -27,7 +27,7 @@ module Mackerel
 
       client_method = client.method(@method)
       response = client_method.call(request_path) do |req|
-        req.headers = @headers
+        req.headers.update @headers
         req.headers['x-api-key'] = @api_key
         req.headers['Content-Type'] ||= JSON_CONTENT_TYPE
         req.params = @params


### PR DESCRIPTION
# Problem

here are some examples.

- initialize 'Authorization' header set when generating a client object by mistake
- initialize 'User-Agent' header ('Faraday v0.15.2') by mistake

# Solution

merge http headers to avoid to initialize http headers that a faraday client object has