### PR TITLE
Use Faraday::Response::RaiseError middleware

### DIFF
--- a/lib/mackerel/api_command.rb
+++ b/lib/mackerel/api_command.rb
@@ -37,7 +37,8 @@ module Mackerel
     rescue Faraday::Error::ClientError => e
       begin
         body = JSON.parse(e.response[:body])
-        raise Mackerel::Error, "#{@method.upcase} #{@path} failed: #{e.response[:status]} #{body["error"]}"
+        message = body["error"].is_a?(Hash) ? body["error"]["message"] : body["error"]
+        raise Mackerel::Error, "#{@method.upcase} #{@path} failed: #{e.response[:status]} #{message}"
       rescue JSON::ParserError
         # raise Mackerel::Error with original response body
         raise Mackerel::Error, "#{@method.upcase} #{@path} failed: #{e.response[:status]} #{e.response[:body]}"

--- a/lib/mackerel/api_command.rb
+++ b/lib/mackerel/api_command.rb
@@ -33,31 +33,18 @@ module Mackerel
         req.params = @params
         req.body = @body
       end
-      check_status(response.status)
-
       JSON.parse(response.body)
+    rescue Faraday::Error::ClientError => e
+      begin
+        body = JSON.parse(e.response[:body])
+        raise Mackerel::Error, "#{@method.upcase} #{@path} failed: #{e.response[:status]} #{body["error"]}"
+      rescue JSON::ParserError
+        # raise Mackerel::Error with original response body
+        raise Mackerel::Error, "#{@method.upcase} #{@path} failed: #{e.response[:status]} #{e.response[:body]}"
+      end
     end
 
     private
-
-    def check_status(status)
-      case status
-      when 200...300
-        nil
-      when 400
-        message ="Invalid parameter"
-        raise "#{@method.upcase} #{@path} failed: #{status} #{message}"
-      when 403
-        message ="Not authorized"
-        raise "#{@method.upcase} #{@path} failed: #{status} #{message}"
-      when 404
-        message ="Resource not found"
-        raise "#{@method.upcase} #{@path} failed: #{status} #{message}"
-      when 409
-        message ="Already exists"
-        raise "#{@method.upcase} #{@path} failed: #{status} #{message}"
-      end
-    end
 
     def make_escaped_query
       @query.map{|k,v| "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}"}.join("&")

--- a/lib/mackerel/client.rb
+++ b/lib/mackerel/client.rb
@@ -4,6 +4,7 @@ require 'uri'
 require 'json' unless defined? ::JSON
 
 require 'mackerel/api_command'
+require 'mackerel/error'
 
 require 'mackerel/role'
 require 'mackerel/host'
@@ -54,6 +55,7 @@ module Mackerel
 
     def http_client
       Faraday.new(:url => @origin) do |faraday|
+        faraday.response :raise_error
         faraday.response :logger if ENV['DEBUG']
         faraday.adapter Faraday.default_adapter
         faraday.options.params_encoder = Faraday::FlatParamsEncoder

--- a/lib/mackerel/error.rb
+++ b/lib/mackerel/error.rb
@@ -1,0 +1,4 @@
+module Mackerel
+  class Error < StandardError
+  end
+end

--- a/spec/mackerel/alert_spec.rb
+++ b/spec/mackerel/alert_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -62,6 +63,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end

--- a/spec/mackerel/annotation_spec.rb
+++ b/spec/mackerel/annotation_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end
@@ -58,6 +59,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -118,6 +120,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.put(api_path) { stubbed_response }
         end
@@ -165,6 +168,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.delete(api_path) { stubbed_response }
         end

--- a/spec/mackerel/api_commend_spec.rb
+++ b/spec/mackerel/api_commend_spec.rb
@@ -1,0 +1,81 @@
+RSpec.describe Mackerel::ApiCommand do
+  let(:api_key) { "xxxxxxxx" }
+  let(:command) { Mackerel::ApiCommand.new(:get, "/api/v0/services", api_key) }
+
+  describe "#execute" do
+    let(:api_path) { "/api/v0/services" }
+
+    let(:test_client) {
+      Faraday.new do |builder|
+        builder.adapter :test do |stubs|
+          stubs.get(api_path) { stubbed_response }
+        end
+      end
+    }
+
+    let(:services) {
+      {
+        "services" => [
+          {
+            "name" => "Web",
+            "memo" => "store",
+            "roles" => [
+              "normal role",
+              "special role"
+            ]
+          },
+          {
+             "name" => "Web",
+             "memo" => "store",
+             "roles" => [
+               "a role",
+               "the role"
+             ]
+          }
+        ]
+      }
+    }
+
+    context "when success" do
+      let(:stubbed_response) {
+        [
+          200,
+          {},
+          JSON.dump(services)
+        ]
+      }
+
+      it {
+        expect(command.execute(test_client)).to eq(services)
+      }
+    end
+
+    context "when 404 Not Found" do
+      let(:stubbed_response) {
+        [
+          404,
+          {},
+          JSON.dump({"error" => "Host Not Found."})
+        ]
+      }
+
+      it {
+        expect { command.execute(test_client) }.to raise_error StandardError, "GET /api/v0/services failed: 404 Resource not found"
+      }
+    end
+
+    context "when 401 Unauthorized" do
+      let(:stubbed_response) {
+        [
+          401,
+          {},
+          JSON.dump({ "error" => "Authentication failed. Please try with valid Api Key." })
+        ]
+      }
+
+      it {
+        expect { command.execute(test_client) }.to raise_error StandardError, "GET /api/v0/services failed: 401 Authentication failed."
+      }
+    end
+  end
+end

--- a/spec/mackerel/api_commend_spec.rb
+++ b/spec/mackerel/api_commend_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Mackerel::ApiCommand do
         [
           404,
           {},
-          JSON.dump({"error" => "Host Not Found."})
+          JSON.dump({"error" => { "message" => "Host Not Found."} })
         ]
       }
 

--- a/spec/mackerel/api_commend_spec.rb
+++ b/spec/mackerel/api_commend_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Mackerel::ApiCommand do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -60,7 +61,7 @@ RSpec.describe Mackerel::ApiCommand do
       }
 
       it {
-        expect { command.execute(test_client) }.to raise_error StandardError, "GET /api/v0/services failed: 404 Resource not found"
+        expect { command.execute(test_client) }.to raise_error Mackerel::Error, "GET /api/v0/services failed: 404 Host Not Found."
       }
     end
 
@@ -74,7 +75,7 @@ RSpec.describe Mackerel::ApiCommand do
       }
 
       it {
-        expect { command.execute(test_client) }.to raise_error StandardError, "GET /api/v0/services failed: 401 Authentication failed."
+        expect { command.execute(test_client) }.to raise_error Mackerel::Error, "GET /api/v0/services failed: 401 Authentication failed. Please try with valid Api Key."
       }
     end
   end

--- a/spec/mackerel/channel_spec.rb
+++ b/spec/mackerel/channel_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end

--- a/spec/mackerel/client_spec.rb
+++ b/spec/mackerel/client_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end
@@ -62,6 +63,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.put(api_path) { stubbed_response }
         end
@@ -104,6 +106,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -159,6 +162,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end
@@ -194,6 +198,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.put(api_path) { stubbed_response }
         end
@@ -236,6 +241,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end
@@ -270,6 +276,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end
@@ -327,6 +334,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -388,6 +396,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end
@@ -433,6 +442,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -466,6 +476,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -501,6 +512,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.put(api_path) { stubbed_response }
         end
@@ -540,6 +552,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.delete(api_path) { stubbed_response }
         end

--- a/spec/mackerel/dashboard_spec.rb
+++ b/spec/mackerel/dashboard_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end
@@ -61,6 +62,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.put(api_path) { stubbed_response }
         end
@@ -110,6 +112,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -160,6 +163,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -208,6 +212,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.delete(api_path) { stubbed_response }
         end

--- a/spec/mackerel/invitation_spec.rb
+++ b/spec/mackerel/invitation_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end
@@ -56,6 +57,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end

--- a/spec/mackerel/metric_spec.rb
+++ b/spec/mackerel/metric_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end
@@ -52,6 +53,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -98,6 +100,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -141,6 +144,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end
@@ -181,6 +185,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -222,6 +227,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end

--- a/spec/mackerel/monitor_spec.rb
+++ b/spec/mackerel/monitor_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end
@@ -59,6 +60,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -125,6 +127,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.put(api_path) { stubbed_response }
         end
@@ -173,6 +176,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.delete(api_path) { stubbed_response }
         end

--- a/spec/mackerel/monitoring_spec.rb
+++ b/spec/mackerel/monitoring_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end

--- a/spec/mackerel/notification_group_spec.rb
+++ b/spec/mackerel/notification_group_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.post(api_path) { stubbed_response }
         end
@@ -76,6 +77,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -159,6 +161,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.put(api_path) { stubbed_response }
         end
@@ -219,6 +222,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.delete(api_path) { stubbed_response }
         end

--- a/spec/mackerel/organization_spec.rb
+++ b/spec/mackerel/organization_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end

--- a/spec/mackerel/service_spec.rb
+++ b/spec/mackerel/service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -71,6 +72,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -120,6 +122,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end

--- a/spec/mackerel/user_spec.rb
+++ b/spec/mackerel/user_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.get(api_path) { stubbed_response }
         end
@@ -64,6 +65,7 @@ RSpec.describe Mackerel::Client do
 
     let(:test_client) {
       Faraday.new do |builder|
+        builder.response :raise_error
         builder.adapter :test do |stubs|
           stubs.delete(api_path) { stubbed_response }
         end


### PR DESCRIPTION
### Why

To raise error when mackerel.io returns 401 Unauthorized

### How

Since `Mackerel::ApiCommand#check_status` is very simple,
change it to use built-in `Faraday::Response::RaiseError` Middleware.

https://github.com/lostisland/faraday/blob/v0.15.4/lib/faraday/response/raise_error.rb

### Breaking Changes

1. Change the error message to json["error"] from API.
2. All 4xx Client Error and 5xx Server Error will raise `Mackerel::Error` (`< StandardError`)

However, NoMethodError would have been raised in these following lines.

i.e. #get_services

https://github.com/mackerelio/mackerel-client-ruby/blob/v0.7.0/lib/mackerel/service.rb#L32-L33

```
data['services'].map {|s| Mackerel::Service.new(s) }
# => NoMethodError (undefined method `map' for nil:NilClass)
```

i.e. #get_host

https://github.com/mackerelio/mackerel-client-ruby/blob/v0.7.0/lib/mackerel/host.rb#L66-L67

```
Mackerel::Host.new(data['host'])
# => NoMethodError (undefined method `[]' for nil:NilClass)
```
