### PR TITLE
Use faraday v1.0

### DIFF
--- a/lib/mackerel/api_command.rb
+++ b/lib/mackerel/api_command.rb
@@ -34,7 +34,7 @@ module Mackerel
         req.body = @body
       end
       JSON.parse(response.body)
-    rescue Faraday::Error::ClientError => e
+    rescue Faraday::ClientError, Faraday::ServerError => e
       begin
         body = JSON.parse(e.response[:body])
         message = body["error"].is_a?(Hash) ? body["error"]["message"] : body["error"]

--- a/mackerel-client.gemspec
+++ b/mackerel-client.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'faraday', '~> 0.9'
+  spec.add_dependency 'faraday', '~> 1.0'
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
faraday v1.0.0 is shipped at 2020-01-01
https://rubygems.org/gems/faraday/versions/1.0.0

In faraday v1.0, `Faraday::Error::ClientError` has been split into `Faraday::ClientError` and `Faraday::SeverError`.

### v1.0.0

https://github.com/lostisland/faraday/blob/ff9dc1d121/lib/faraday/response/raise_error.rb#L9-L10
https://github.com/lostisland/faraday/blob/ff9dc1d121/lib/faraday/response/raise_error.rb#L31-L34

### v0.17.3

https://github.com/lostisland/faraday/blob/v0.17.3/lib/faraday/response/raise_error.rb#L3
https://github.com/lostisland/faraday/blob/v0.17.3/lib/faraday/response/raise_error.rb#L14-L15

## FYI

* `Faraday::Error::Client` is deprecated (since v0.17.1)
  - https://github.com/lostisland/faraday/commit/6e746fceefe0d1f75535b40a62d846a6a95bf85f
* `Faraday::Response::RaiseError` uses `Faraday::ClientError` instead of `Faraday::Error::Client` (since v0.17.1)
  - https://github.com/lostisland/faraday/commit/6ab10ad8ef3e0ed62b04714e0e130e14a7903505

---

Should I add a test for raise `Faraday::ServerError` ?