### PR TITLE
Implements downtime API

### DIFF
--- a/lib/mackerel/client.rb
+++ b/lib/mackerel/client.rb
@@ -21,6 +21,7 @@ require 'mackerel/metric'
 require 'mackerel/metadata'
 require 'mackerel/notification_group'
 require 'mackerel/channel'
+require 'mackerel/downtime'
 
 module Mackerel
   class Client
@@ -38,6 +39,7 @@ module Mackerel
     include Mackerel::REST::Metadata
     include Mackerel::REST::Channel
     include Mackerel::REST::NotificationGroup
+    include Mackerel::REST::Downtime
 
     def initialize(args = {})
       @origin       = args[:mackerel_origin]  || 'https://api.mackerelio.com'

--- a/lib/mackerel/downtime.rb
+++ b/lib/mackerel/downtime.rb
@@ -1,0 +1,27 @@
+module Mackerel
+  module REST
+    module Downtime
+      def create_downtime(downtime)
+        command = ApiCommand.new(:post, "/api/v0/downtimes", @api_key)
+        command.body = downtime.to_json
+        command.execute(client)
+      end
+
+      def list_downtime()
+        command = ApiCommand.new(:get, "/api/v0/downtimes", @api_key)
+        command.execute(client)
+      end
+
+      def update_downtime(downtime_id, downtime)
+        command = ApiCommand.new(:put, "/api/v0/downtimes/#{downtime_id}", @api_key)
+        command.body = downtime.to_json
+        command.execute(client)
+      end
+
+      def delete_downtime(downtime_id)
+        command = ApiCommand.new(:delete, "/api/v0/downtimes/#{downtime_id}", @api_key)
+        command.execute(client)
+      end
+    end
+  end
+end

--- a/lib/mackerel/downtime.rb
+++ b/lib/mackerel/downtime.rb
@@ -1,13 +1,13 @@
 module Mackerel
   module REST
     module Downtime
-      def create_downtime(downtime)
+      def post_downtime(downtime)
         command = ApiCommand.new(:post, "/api/v0/downtimes", @api_key)
         command.body = downtime.to_json
         command.execute(client)
       end
 
-      def list_downtime()
+      def get_downtimes()
         command = ApiCommand.new(:get, "/api/v0/downtimes", @api_key)
         command.execute(client)
       end

--- a/spec/mackerel/downtime_spec.rb
+++ b/spec/mackerel/downtime_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Mackerel::Client do
   let(:api_key) { 'xxxxxxxx' }
   let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
 
-  describe '#create_downtime' do
+  describe '#post_downtime' do
     let(:stubbed_response) {
       [
         200,
@@ -47,12 +47,12 @@ RSpec.describe Mackerel::Client do
       allow(client).to receive(:http_client).and_return(test_client)
     end
 
-    it "successfully create downtime" do
-      expect(client.create_downtime(downtime).to_h).to eq(response_object)
+    it "successfully post downtime" do
+      expect(client.post_downtime(downtime).to_h).to eq(response_object)
     end
   end
 
-  describe '#list_downtime' do
+  describe '#get_downtimes' do
     let(:stubbed_response) {
       [
         200,
@@ -93,8 +93,8 @@ RSpec.describe Mackerel::Client do
       allow(client).to receive(:http_client).and_return(test_client)
     end
 
-    it "successfully list downtime" do
-      expect(client.list_downtime.to_h).to eq(response_object)
+    it "successfully get downtimes" do
+      expect(client.get_downtimes.to_h).to eq(response_object)
     end
   end
 

--- a/spec/mackerel/downtime_spec.rb
+++ b/spec/mackerel/downtime_spec.rb
@@ -1,0 +1,192 @@
+RSpec.describe Mackerel::Client do
+  let(:api_key) { 'xxxxxxxx' }
+  let(:client) { Mackerel::Client.new(:mackerel_api_key => api_key) }
+
+  describe '#create_downtime' do
+    let(:stubbed_response) {
+      [
+        200,
+        {},
+        JSON.dump(response_object)
+      ]
+    }
+
+    let(:test_client) {
+      Faraday.new do |builder|
+        builder.response :raise_error
+        builder.adapter :test do |stubs|
+          stubs.post(api_path) { stubbed_response }
+        end
+      end
+    }
+
+    let(:api_path) { '/api/v0/downtimes' }
+    let(:downtime_id) { 'abcxyz' }
+    let(:name) { 'HogeHoge' }
+    let(:start) { 1234567890 }
+    let(:duration) { 10 }
+
+    let(:response_object) {
+      {
+        'id' => downtime_id,
+        'name' => name,
+        'start' => start,
+        'duration' => duration
+      }
+    }
+
+    let(:downtime) {
+      {
+        'name' => name,
+        'start' => start,
+        'duration' => duration
+      }
+    }
+
+    before do
+      allow(client).to receive(:http_client).and_return(test_client)
+    end
+
+    it "successfully create downtime" do
+      expect(client.create_downtime(downtime).to_h).to eq(response_object)
+    end
+  end
+
+  describe '#list_downtime' do
+    let(:stubbed_response) {
+      [
+        200,
+        {},
+        JSON.dump(response_object)
+      ]
+    }
+
+    let(:test_client) {
+      Faraday.new do |builder|
+        builder.response :raise_error
+        builder.adapter :test do |stubs|
+          stubs.get(api_path) { stubbed_response }
+        end
+      end
+    }
+
+    let(:api_path) { '/api/v0/downtimes' }
+    let(:downtime_id) { 'abcxyz' }
+    let(:name) { 'HogeHoge' }
+    let(:start) { 1234567890 }
+    let(:duration) { 10 }
+
+    let(:response_object) {
+      {
+        'downtimes' => [
+          {
+            'id' => downtime_id,
+            'name' => name,
+            'start' => start,
+            'duration' => duration
+          }
+        ]
+      }
+    }
+
+    before do
+      allow(client).to receive(:http_client).and_return(test_client)
+    end
+
+    it "successfully list downtime" do
+      expect(client.list_downtime.to_h).to eq(response_object)
+    end
+  end
+
+  describe '#update_downtime' do
+    let(:stubbed_response) {
+      [
+        200,
+        {},
+        JSON.dump(response_object)
+      ]
+    }
+
+    let(:test_client) {
+      Faraday.new do |builder|
+        builder.response :raise_error
+        builder.adapter :test do |stubs|
+          stubs.put(api_path) { stubbed_response }
+        end
+      end
+    }
+
+    let(:api_path) { "/api/v0/downtimes/#{downtime_id}" }
+    let(:downtime_id) { 'abcxyz' }
+    let(:name) { 'HogeHoge' }
+    let(:start) { 1234567890 }
+    let(:duration) { 10 }
+
+    let(:response_object) {
+      {
+        'id' => downtime_id,
+        'name' => name,
+        'start' => start,
+        'duration' => duration
+      }
+    }
+
+    let(:downtime) {
+      {
+        'name' => name,
+        'start' => start,
+        'duration' => duration
+      }
+    }
+
+    before do
+      allow(client).to receive(:http_client).and_return(test_client)
+    end
+
+    it "successfully update downtime" do
+      expect(client.update_downtime(downtime_id, downtime).to_h).to eq(response_object)
+    end
+  end
+
+  describe '#delete_downtime' do
+    let(:stubbed_response) {
+      [
+        200,
+        {},
+        JSON.dump(response_object)
+      ]
+    }
+
+    let(:test_client) {
+      Faraday.new do |builder|
+        builder.response :raise_error
+        builder.adapter :test do |stubs|
+          stubs.delete(api_path) { stubbed_response }
+        end
+      end
+    }
+
+    let(:api_path) { "/api/v0/downtimes/#{downtime_id}" }
+    let(:downtime_id) { 'abcxyz' }
+    let(:name) { 'HogeHoge' }
+    let(:start) { 1234567890 }
+    let(:duration) { 10 }
+
+    let(:response_object) {
+      {
+        'id' => downtime_id,
+        'name' => name,
+        'start' => start,
+        'duration' => duration
+      }
+    }
+
+    before do
+      allow(client).to receive(:http_client).and_return(test_client)
+    end
+
+    it "successfully delete downtime" do
+      expect(client.delete_downtime(downtime_id).to_h).to eq(response_object)
+    end
+  end
+end


### PR DESCRIPTION
I want to call `/api/v0/downtime` API using mackerel-client-ruby, but it seems not to implement yet.
https://mackerel.io/ja/api-docs/entry/downtimes#create

If these API are already implemented, or there is some reason why it doesn't implement , please tell me and close this PR. 

thanks.