### PR TITLE
Add get monitor

### DIFF
--- a/lib/mackerel/monitor.rb
+++ b/lib/mackerel/monitor.rb
@@ -54,13 +54,13 @@ module Mackerel
       end
 
       def get_monitors()
-        command = ApiCommand.new(:get,'/api/v0/monitors', @api_key)
+        command = ApiCommand.new(:get, '/api/v0/monitors', @api_key)
         data = command.execute(client)
         data['monitors'].map{ |m| Mackerel::Monitor.new(m) }
       end
 
       def get_monitor(monitor_id)
-        command = ApiCommand.new(:get,"/api/v0/monitors/#{monitor_id}", @api_key)
+        command = ApiCommand.new(:get, "/api/v0/monitors/#{monitor_id}", @api_key)
         data = command.execute(client)
         Mackerel::Monitor.new(data)
       end

--- a/lib/mackerel/monitor.rb
+++ b/lib/mackerel/monitor.rb
@@ -62,7 +62,7 @@ module Mackerel
       def get_monitor(monitor_id)
         command = ApiCommand.new(:get, "/api/v0/monitors/#{monitor_id}", @api_key)
         data = command.execute(client)
-        Mackerel::Monitor.new(data)
+        Mackerel::Monitor.new(data['monitor'])
       end
 
       def update_monitor(monitor_id, monitor)

--- a/lib/mackerel/monitor.rb
+++ b/lib/mackerel/monitor.rb
@@ -59,6 +59,12 @@ module Mackerel
         data['monitors'].map{ |m| Mackerel::Monitor.new(m) }
       end
 
+      def get_monitor(monitor_id)
+        command = ApiCommand.new(:get,"/api/v0/monitors/#{monitor_id}", @api_key)
+        data = command.execute(client)
+        Mackerel::Monitor.new(data)
+      end
+
       def update_monitor(monitor_id, monitor)
         command = ApiCommand.new(:put, "/api/v0/monitors/#{monitor_id}", @api_key)
         command.body = monitor.to_json

--- a/spec/mackerel/monitor_spec.rb
+++ b/spec/mackerel/monitor_spec.rb
@@ -116,6 +116,55 @@ RSpec.describe Mackerel::Client do
     end
   end
 
+  describe '#get_monitor' do
+    let(:stubbed_response) {
+      [
+        200,
+        {},
+        JSON.dump(response_object)
+      ]
+    }
+
+    let(:test_client) {
+      Faraday.new do |builder|
+        builder.response :raise_error
+        builder.adapter :test do |stubs|
+          stubs.get(api_path) { stubbed_response }
+        end
+      end
+    }
+
+    let(:api_path) { "/api/v0/monitors/#{monitor_id}" }
+    let(:monitor_id) { 'qwertyui' }
+
+    let(:monitor) {
+      {
+        'id' => monitor_id,
+        'type' => 'host',
+        'name' => 'monitor001',
+        'duration' => 5,
+        'metric' => 'loadavg5',
+        'operator' => '>',
+        'warning' => 4,
+        'critical' => 6,
+        'notificationInterval' => 600,
+        'isMute' => false,
+      }
+    }
+
+    let(:response_object) {
+      monitor
+    }
+
+    before do
+      allow(client).to receive(:http_client).and_return(test_client)
+    end
+
+    it "successfully get monitor" do
+      expect(client.get_monitor(monitor_id).to_h).to eq(response_object)
+    end
+  end
+
   describe '#update_monitor' do
     let(:stubbed_response) {
       [

--- a/spec/mackerel/monitor_spec.rb
+++ b/spec/mackerel/monitor_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Mackerel::Client do
     }
 
     let(:response_object) {
-      monitor
+      { 'monitor' => monitor }
     }
 
     before do
@@ -161,7 +161,7 @@ RSpec.describe Mackerel::Client do
     end
 
     it "successfully get monitor" do
-      expect(client.get_monitor(monitor_id).to_h).to eq(response_object)
+      expect(client.get_monitor(monitor_id).to_h).to eq(response_object['monitor'])
     end
   end
 


### PR DESCRIPTION
I want to get a monitor by its id.

```ruby
client = Mackerel::Client.new(:mackerel_api_key => ENV['MACKEREL_APIKEY'])
m = client.get_monitor('********')
pp m
```

output
```sh
#<Mackerel::Monitor:*****
 @certificationExpirationCritical=nil,
 @certificationExpirationWarning=nil,
 @containsString=nil,
 @critical=***,
 @duration=***,
 @excludeScopes=[],
 @expression=nil,
 @id="*****",
 @isMute=false,
 @maxCheckAttempts=1,
 @metric="******",
 @name="******",
.....
```

