### PR TITLE
Add suspendedAt to Channels API

### DIFF
--- a/lib/mackerel/channel.rb
+++ b/lib/mackerel/channel.rb
@@ -1,10 +1,11 @@
 module Mackerel
   class Channel
-    attr_accessor :id, :name, :type
+    attr_accessor :id, :name, :type, :suspendedAt
     def initialize(args = {})
       @id                 = args["id"]
       @name               = args["name"]
       @type               = args["type"]
+      @suspendedAt        = args["suspendedAt"]
     end
 
     def to_h

--- a/spec/mackerel/channel_spec.rb
+++ b/spec/mackerel/channel_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Mackerel::Client do
     let(:channels) { 
       {
         "channels" => [
-          { "id" => "361DhijkGFS" , "name" => "Default", "type" => "email" },
+          { "id" => "361DhijkGFS" , "name" => "Default", "type" => "email", "suspendedAt" => 12345678 },
           { "id" => "361FijklHGT" , "name" => "alert_infomation", "type" => "slack" }
         ]
       }


### PR DESCRIPTION
`suspendedAt` is added to Channels API.
https://mackerel.io/ja/api-docs/entry/channels#get