### PR TITLE
Drop 2.6 and add 3.2 and 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macOS-latest']
         # See https://github.com/actions/runner/issues/849 for quoting '3.0'
-        ruby: [2.6, 2.7, '3.0', 3.1]
+        ruby: [2.7, '3.0', 3.1, 3.2, 3.3]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Ruby 2.6 is EOL
Ruby 3.2 and 3.3 are available
https://www.ruby-lang.org/ja/downloads/branches/